### PR TITLE
feat(*): add demos.tf support

### DIFF
--- a/scripting/include/demostf.inc
+++ b/scripting/include/demostf.inc
@@ -1,0 +1,6 @@
+#if defined _demostf_included
+    #endinput
+#endif
+#define _demostf_included
+
+forward DemoUploaded(bool success, const char[] demoid, const char[] url);


### PR DESCRIPTION
Adds support for demos.tf links.
If the demos.tf plugin is loaded when the `payload-webhook` plugin has been loaded, it allows the webhook to post the corresponding demos.tf link as well.